### PR TITLE
fix: Update CPU runs-on labels

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,9 @@ on:
   - push
 jobs:
   cfn-lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: self-hosted
+      labels: cpu
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Update workflow to use `cpu` instead of `cpu-dind` for runs-on labels